### PR TITLE
Fixed CastError

### DIFF
--- a/lib/src/widgets/connectivity_screen_wrapper.dart
+++ b/lib/src/widgets/connectivity_screen_wrapper.dart
@@ -96,10 +96,10 @@ class ConnectivityScreenWrapper extends StatelessWidget {
     return AbsorbPointer(
       absorbing: (disableInteraction && isOffline),
       child: Stack(
-        children: (<Widget?>[
-          if (child != null) child,
+        children: (<Widget>[
+          if (child != null) child!,
           if (disableInteraction && isOffline)
-            if (disableWidget != null) disableWidget,
+            if (disableWidget != null) disableWidget!,
           _offlineWidget,
         ]) as List<Widget>,
       ),

--- a/lib/src/widgets/connectivity_widget_wrapper.dart
+++ b/lib/src/widgets/connectivity_widget_wrapper.dart
@@ -97,8 +97,8 @@ class ConnectivityWidgetWrapper extends StatelessWidget {
 
     if (stacked)
       return Stack(
-        children: (<Widget?>[
-          if (child != null) child,
+        children: (<Widget>[
+          if (child != null) child!,
           disableInteraction && _isOffline
               ? Column(
                   children: <Widget>[


### PR DESCRIPTION
Fixed Errors occurred in `connectivity_widget_wrapper.dart` and `connectivity_screen_wrapper.dart`

_Error:_ `type 'List<Widget?>' is not a subtype of type 'List<Widget>' in type cast`